### PR TITLE
add link to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -89,6 +89,7 @@ by issuing the @helpers command to the #code4lib bot named "zoia". More info on 
           <li><a href="http://code4lib.org/">Code4Lib Website</a></li>
           <li><a href="http://wiki.code4lib.org/index.php/Main_Page">Code4Lib Wiki</a></li>
           <li><a href="http://code4lib.org/irc">Code4Lib IRC Info</a></li>
+          <li><a href="http://wiki.code4lib.org/index.php/Main_Page#Earlier_Conferences_and_events">Past Conference Info</a></li>
 
         </ul>
     </div>


### PR DESCRIPTION
Added link to wiki: http://wiki.code4lib.org/Main_Page#Earlier_Conferences_and_events
