### PR TITLE
One sponsor level per row in prospectus

### DIFF
--- a/prospectus.html
+++ b/prospectus.html
@@ -115,13 +115,13 @@ title: Sponsors
     <div class="cell cell-lg">
       <h2>Sponsorship Opportunities</h2>
       <div class="row">
-        <div class="col-xs-12 col-sm-6 col-md-4">
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Platinum</h3>
             <p><b>$7500 and above</b></p>
             <ul>
               <li>Large logo or Name on website and online program as Platinum Sponsor
-              <li>Large logo on conference T-shirt (b&w vector image required)
+              <li>Large logo on conference T-shirt (b&amp;w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
               <li> Brochure in conference packet
               <li>Logo on Poster in Ballroom
@@ -129,13 +129,15 @@ title: Sponsors
             </ul>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-6 col-md-4">
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Gold</h3>
             <p><b>$5000 - $7499</b></p>
             <ul>
               <li>Medium logo or Name on website, online program as Gold Sponsor
-              <li>Medium logo on conference T-shirt (b&w vector image required)
+              <li>Medium logo on conference T-shirt (b&amp;w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
               <li> Brochure in conference packet
               <li>Logo on Ballroom “Screensaver”
@@ -143,13 +145,15 @@ title: Sponsors
             </ul>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-6 col-md-4">
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Silver</h3>
             <p><b>$2500 - $4999</b></p>
             <ul>
               <li>Small logo or Name on website and online program as Silver Sponsor
-              <li>Small logo on conference T-shirt (b&w vector image required)
+              <li>Small logo on conference T-shirt (b&amp;w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
               <li>Brochure in conference packet
             </ul>
@@ -157,7 +161,7 @@ title: Sponsors
         </div>
       </div>
       <div class="row">
-        <div class="col-xs-12 col-sm-6 col-md-4">
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Bronze</h3>
             <p><b>$1000 - $2500</b></p>
@@ -168,7 +172,9 @@ title: Sponsors
             </ul>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-6 col-md-4">
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Contributor</h3>
             <p><b>$250 - $999</b></p>
@@ -177,7 +183,9 @@ title: Sponsors
             </ul>
           </div>
         </div>
-        <div class="col-xs-12 col-sm-6 col-md-4">
+      </div>
+      <div class="row">  
+        <div class="col-xs-12">
           <div class="thumbnail">
             <h3>Supporter</h3>
             <p><b>Under $250 or non-monetary</b></p>


### PR DESCRIPTION
Each sponsor level by itself in a row, for easier readability.

I suggested this to the sponsorhsip group and got some feedback that it was a good idea, so here's a pull request that you can merge if you feel so inclined. 
