### PR TITLE
Add page for prepared talks. Update schedule

### DIFF
--- a/prepared-talks.html
+++ b/prepared-talks.html
@@ -1,0 +1,35 @@
+---
+layout: default
+title: Prepared Talks
+categories: talks
+---
+
+    <div class="row section" id="prepared-talks">
+        <div class="cell cell-lg">
+            <div class="row">
+                <div class="col-xs-12">
+                	<h2>Proposals for Prepared Talks</h2>
+                	<p>Prepared talks are 20 minutes (including setup and questions), and should focus on one or more of the following areas:
+                		<ul>
+                			<li>Projects you've worked on which incorporate innovative implementation of existing technologies and/or development of new software</li>
+                			<li>Tools and technologies – How to get the most out of existing tools, standards and protocols (and ideas on how to make them better)</li>
+                			<li>Technical issues - Big issues in library technology that should be addressed or better understood</li>
+                			<li>Relevant non-technical issues – Concerns of interest to the Code4Lib community which are not strictly technical in nature, e.g. collaboration, diversity, organizational challenges, etc.</li>
+                		</ul>
+                	</p>
+                	<a class="btn btn-primary btn-lg" href="https://docs.google.com/forms/d/1RaLyRyv_gHHPynDk2WIwC5JAcUiY0w8tsFq5YwEnsv4/viewform">Propose a Talk</a>
+                </div>
+                <div class="col-xs-12">
+                	<h3> Selection Process</h3>
+                	<p>
+                	As in past years, the Code4Lib community will vote on proposals that they would like to see included in the program. The top 10 proposals are guaranteed a slot at the conference. The Program Committee will curate the remainder of the program in an effort to ensure diversity in program content and presenters.  Community votes will, of course, still weigh heavily in these decisions.
+                </p>
+                <p>
+                Presenters whose proposals are selected for inclusion in the program will be guaranteed an opportunity to register for the conference. The standard conference registration fee will still apply. Proposals can be submitted through Monday, November 9, 2015 at midnight PST (GMT−8). Voting will start on November 16, 2015 and continue through December 7, 2015. The URL to submit votes will be announced on the Code4Lib website and mailing list and will require an active <a href="http://code4lib.org">code4lib.org</a> account to participate. The final list of presentations will be announced in mid-December.
+                </p>
+                </div>
+            </div>
+        </div>
+    </div>    
+
+

--- a/schedule.html
+++ b/schedule.html
@@ -42,9 +42,11 @@ categories: Schedule
                 </div>
                 <div class="col-xs-12 col-sm-7">
                     <h2>Call for Conference Proposals</h2>
+                    <a href="/prepared-talks.html">About Talk Proposals</a>
                 </div>
                 <div class="col-xs-12 col-sm-5 text-right">
-                    <h2><small class="light">TBD</small></h2>
+                    <h2><small class="light">10/12 - 11/09</small></h2>
+                    <a class="btn btn-primary btn-lg" href="https://docs.google.com/forms/d/1RaLyRyv_gHHPynDk2WIwC5JAcUiY0w8tsFq5YwEnsv4/viewform">Propose a Talk</a>
                 </div>
                 <div class="col-xs-12 col-sm-7">
                     <h2>Conference Proposal Voting</h2>

--- a/schedule.html
+++ b/schedule.html
@@ -41,6 +41,13 @@ categories: Schedule
                     <p><a href="http://vote.code4lib.org/election/38" class="btn btn-primary pull-right">Vote!</a></p>
                 </div>
                 <div class="col-xs-12 col-sm-7">
+                    <h2>Call for Preconference Workshops</h2>
+                </div>
+                <div class="col-xs-12 col-sm-5 text-right">
+                    <h2><small class="light">10/7 - 11/15</small></h2>
+                    <a class="btn btn-primary btn-lg" href="http://bit.ly/c4l16preconf" target="_blank">Propose a Workshop</a>
+                </div>
+                <div class="col-xs-12 col-sm-7">
                     <h2>Call for Conference Proposals</h2>
                     <a href="/prepared-talks.html">About Talk Proposals</a>
                 </div>


### PR DESCRIPTION
Making this pull request speculatively. I was sending out something about the call for talk proposals but had nowhere to link to so:

Adds a page with the text of the email calling for talk proposals.

Updates the schedule to indicate that the call for proposals is open.
