### PR TITLE
updated prospectus ... 

### DIFF
--- a/prospectus.html
+++ b/prospectus.html
@@ -129,9 +129,10 @@ title: Sponsors
               <li>Large logo or Name on website and online program as Platinum Sponsor
               <li>Large logo on conference T-shirt (b&w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
-              <li> Brochure in conference packet
+              <li>Brochure in conference packet
               <li>Logo on Poster in Ballroom
               <li>2 free conference registrations
+              <li>Platinum "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -144,9 +145,10 @@ title: Sponsors
               <li>Medium logo or Name on website, online program as Gold Sponsor
               <li>Medium logo on conference T-shirt (b&w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
-              <li> Brochure in conference packet
+              <li>Brochure in conference packet
               <li>Logo on Ballroom “Screensaver”
               <li>1 free conference registration
+              <li>Gold "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -160,6 +162,7 @@ title: Sponsors
               <li>Small logo on conference T-shirt (b&w vector image required)
               <li>Acknowledgement from podium at opening and closing sessions
               <li>Brochure in conference packet
+              <li>Silver "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -169,11 +172,12 @@ title: Sponsors
           <div class="thumbnail">
             <img src="{{ site.data.path }}img/badges/bronze.png" alt="bronze badge"/>
             <h3>Bronze</h3>
-            <p><b>$1000 - $2500</b></p>
+            <p><b>$1000 - $2499</b></p>
             <ul>
-              <li>Name on website and online program as Bronze Sponsor
+              <li>Small logo on website and online program as Bronze Sponsor
               <li>Name on conference T-shirt
               <li>Acknowledgement from podium at opening and closing sessions
+              <li>Bronze "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -183,7 +187,9 @@ title: Sponsors
             <h3>Contributor</h3>
             <p><b>$250 - $999</b></p>
             <ul>
-              <li>Name on website and online program as Contributor
+              <li>Small logo on website and online program as Contributor
+              <li>Acknowledgement from podium at opening and closing sessions
+              <li>Contributor "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -193,8 +199,9 @@ title: Sponsors
             <h3>Supporter</h3>
             <p><b>Under $250 or non-monetary</b></p>
             <ul>
-              <li>Name on website
+              <li>Name on website and online program as Supporter
               <li>Recognition at appropriate time (i.e., during raffles for prize donations)
+              <li>Supporter "Badge of Distinction" color printed on nametags of sponsor's attendees
             </ul>
           </div>
         </div>
@@ -318,7 +325,7 @@ title: Sponsors
           <div class="thumbnail">
             <a name="Realtime-Transcription"></a>
             <h3>Real-time Transcription and Closed Captioning of Talks</h3>
-            <b>1 available @ $2000 </b> <br/>
+            <b>1 available @ $2000, 0 left </b> <br/>
             <p>To facilitate universal participation and access to conference content, real-time live transcription and closed captioning of all presentations, lightning talks, and announcements from the podium at the annual Code4Lib conference will be included with the webstream and in-person, along with full transcription after the fact to accompany recordings.
               <ul>
                 <li>Daily recognition from podium</li>
@@ -334,7 +341,7 @@ title: Sponsors
           <div class="thumbnail">
             <a name="Childcare"></a>
             <h3>Childcare</h3>
-            <b> 1 available @ $2000 </b> <br/>
+            <b>2 available @ $2000, 1 left </b> <br/>
             <p>
               On-site childcare is provided at the code4lib Conference to make it possible for working
               parents to attend and fully participate. This sponsorship helps to offset the cost of


### PR DESCRIPTION
... and sweetened the deal on Badges of Distinction sponsorships.

@bibliotechy can you have a look at this?  I didn't hear any objections from the Sponsorship Committee when I floated the idea of sweetening the deal for Contributor Sponsors (logo on site) and printing "Badges of Distinction" on sponsor attendees name tags.  Many companies like Balsamiq and Github will give $500 as a matter of policy, but want their logo on the site.  I think that's fair if it's under the Contributor heading.  So, have a look and merge the PR if satisfied.  Thanks!
