### PR TITLE
venue shuttle info, closes #294

### DIFF
--- a/venue.html
+++ b/venue.html
@@ -38,6 +38,7 @@ title: Venue
         <h3>Getting Here</h3>
         <p>The conference will be located at the <a href="http://www.sheratonphiladelphiasocietyhill.com/society-hill-hotel-directions">Sheraton Philadelphia Society Hill Hotel</a> at One Dock Street, by the 2nd and Walnut St. intersection. The <a href="http://www.phl.org/Pages/HomePage.aspx">Philadelphia International Airport</a> is the closest major airport to the conference, with easy metro access to the conference hotel. Amtrak trains also run through Philadelphia and the 30th Street Station connects to the Philadelphia subway; the MFL line takes you towards the hotel.</p>
         <h3>Airport to the Conference Site</h3>
+        <p>The Sheraton works with <a href="http://www.ladylibertyshuttle.com/">the Lady Liberty shuttle service</a>, which provides shuttles from the airport for $10.  It is easiest to call them directly to schedule a pick up; their phone number is <a href="tel:215-724-8888">215-724-8888</a> and there are kiosks at baggage claim that connect directly to the shuttle company. To return to the airport, the hotel's Front Desk or Concierge can assist with shuttle reservations.</p>
         <p>The airport is about a twenty-minute drive from the Old District of Philadelphia.</p>
         <p>On public transit, the subway has an Airport Line which goes to the center of the city. You can ride it to the Market & 11th street station, where the MFL line takes you towards the conference location.</p>
         {% comment %} fluid-width iframe {% endcomment %}


### PR DESCRIPTION
add in information on the hotel shuttle with links to the service

while @billmcmillin's edit on #290 touches the same page these shouldn't conflict, both just adding a line to the "Airport to conference site" section
