### PR TITLE
Add explicit ref to page w/addresses, fix end time

### DIFF
--- a/schedule/index.html
+++ b/schedule/index.html
@@ -26,13 +26,13 @@ title: Schedule
             </div>
             <div class="row">
               <div class="col-xs-12 col-md-3 text-right">
-                  <h4>9AM - 5PM</h4>
+                  <h4>9AM - 4:30PM</h4>
               </div>
               <div class="col-xs-12 col-md-9 sched-well">
                   <h3><a href="/workshops">Preconference Workshops</a></h3>
                   <p>Workshops will take place at the <a href="http://www.chemheritage.org/">Chemical Heritage Foundation</a>, 
                    <a href="https://www.amphilsoc.org/">American Philosophical Society</a>'s Franklin Hall, and at the
-                   <a href="/venue.html">Sheraton Society Hill</a>.<a href="/workshops">Browse selected workshops</a>.
+                   <a href="/venue.html">Sheraton Society Hill</a>. See address information for these locations on the <a href="/venue.html">Venue page</a>. <a href="/workshops">Browse selected workshops and/or get locations and times for each</a>.
                   </p>
                   <a href="childcare.html">Childcare</a> is provided thanks to Equinox and CurateCamp. Dropoff will be at the Sheraton.</p>
               </div>


### PR DESCRIPTION
This is to add an explicit reference to the Venue page that contains the addresses for the Preconference locations, as well as update the end time to be 4:30. Also want to say that the _correct_ preconference times are listed on the card for each in the Browse workshops section.
